### PR TITLE
refactor: Use KV linked list in hash table

### DIFF
--- a/include/base/hash_table.h
+++ b/include/base/hash_table.h
@@ -3,179 +3,8 @@
 
 #include <stdbool.h>
 
-#include "base/generic.h"
-#include "base/linked_list.h"
-
-/**
- * \struct hash_table_entry
- * \brief Hash map entry type.
- */
-typedef struct hash_table_entry hash_table_entry;
-
-/**
- * \internal
- * \struct hash_table_entry
- * \brief Hash map entry type.
- */
-struct hash_table_entry
-{
-    any key;
-    any value;
-};
-
-typedef struct hash_table_entry_copy_transfer hash_table_entry_copy_transfer;
-
-/**
- * \internal
- * \struct hash_table_entry_copy_transfer
- * \brief Hash map entry copy transfer type.
- */
-struct hash_table_entry_copy_transfer
-{
-    hash_table_entry *entry;
-
-    generic_copy copy_key_fn;
-    generic_copy copy_value_fn;
-};
-
-typedef struct hash_table_entry_free_transfer hash_table_entry_free_transfer;
-
-/**
- * \internal
- * \struct hash_table_entry_free_transfer
- * \brief Hash map entry free transfer type.
- */
-struct hash_table_entry_free_transfer
-{
-    hash_table_entry *entry;
-
-    generic_free free_key_fn;
-    generic_free free_value_fn;
-};
-
-/**
- * \fn any hash_table_entry_copy(any entry_data)
- * \brief Copies a hash map entry.
- * \return The copied hash map entry.
- * \param entry_data The hash map entry to copy.
- */
-any hash_table_entry_copy(any entry_data);
-
-/**
- * \fn void hash_table_entry_free(any entry_data)
- * \brief Frees a hash map entry.
- * \param entry_data The hash map entry to free.
- */
-void hash_table_entry_free(any entry_data);
-
-/**
- * \fn void hash_table_entry_print(any entry_data, generic_print print_key_fn, generic_print print_value_fn)
- * \brief Prints a hash map entry.
- * \param entry_data The hash map entry to print.
- * \param print_key_fn The function to print the key.
- * \param print_value_fn The function to print the value.
- */
-void hash_table_entry_print(any entry_data, generic_print print_key_fn, generic_print print_value_fn);
-
-/**
- * \typedef linked_list hash_table_bucket
- * \brief Hash map bucket type.
- */
-typedef linked_list hash_table_bucket;
-
-/**
- * \fn hash_table_bucket hash_table_bucket_create(void)
- * \brief Creates a hash map bucket.
- * \return The created hash map bucket.
- */
-hash_table_bucket hash_table_bucket_create(void);
-
-/**
- * \fn bool hash_table_bucket_is_empty(hash_table_bucket bucket)
- * \brief Checks if a hash map bucket is empty.
- * \return Whether the hash map bucket is empty.
- * \param bucket The hash map bucket to check.
- */
-bool hash_table_bucket_is_empty(hash_table_bucket bucket);
-
-/**
- * \fn hash_table_bucket hash_table_bucket_get_next(hash_table_bucket bucket)
- * \brief Gets the next hash map bucket.
- * \return The next hash map bucket.
- * \param bucket The hash map bucket to get the next hash map bucket from.
- */
-hash_table_bucket hash_table_bucket_get_next(hash_table_bucket bucket);
-
-/**
- * \fn void hash_table_bucket_set_next(hash_table_bucket bucket, hash_table_bucket next)
- * \brief Sets the next hash map bucket.
- * \param bucket The hash map bucket to set the next hash map bucket from.
- * \param next The next hash map bucket to set.
- */
-void hash_table_bucket_set_next(hash_table_bucket bucket, hash_table_bucket next);
-
-/**
- * \fn hash_table_entry hash_table_bucket_get_data(hash_table_bucket bucket)
- * \brief Gets the data of a hash map bucket.
- * \return The data of the hash map bucket.
- * \param bucket The hash map bucket to get the data from.
- */
-hash_table_entry hash_table_bucket_get_data(hash_table_bucket bucket);
-
-/**
- * \fn void hash_table_bucket_set_data(hash_table_bucket bucket, hash_table_entry data, generic_copy copy_key_fn, generic_copy copy_value_fn)
- * \brief Sets the data of a hash map bucket.
- * \param bucket The hash map bucket to set the data from.
- * \param data The data to set.
- * \param copy_key_fn The function to copy the key.
- * \param copy_value_fn The function to copy the value.
- */
-void hash_table_bucket_set_data(hash_table_bucket bucket, hash_table_entry data, generic_copy copy_key_fn, generic_copy copy_value_fn);
-
-/**
- * \fn long int hash_table_bucket_length(hash_table_bucket bucket)
- * \brief Gets the length of a hash map bucket.
- * \return The length of the hash map bucket.
- * \param bucket The hash map bucket to get the length from.
- */
-long int hash_table_bucket_length(hash_table_bucket bucket);
-
-/**
- * \fn void hash_table_bucket_insert(hash_table_bucket *bucket, hash_table_entry data, generic_copy copy_key_fn, generic_copy copy_value_fn)
- * \brief Inserts data into a hash map bucket.
- * \param bucket The hash map bucket to insert the data into.
- * \param data The data to insert.
- * \param copy_key_fn The function to copy the key.
- * \param copy_value_fn The function to copy the value.
- */
-void hash_table_bucket_insert(hash_table_bucket *bucket, hash_table_entry data, generic_copy copy_key_fn, generic_copy copy_value_fn);
-
-/**
- * \fn void hash_table_bucket_remove(hash_table_bucket *bucket, generic_free free_key_fn, generic_free free_value_fn)
- * \brief Removes data from a hash map bucket.
- * \param bucket The hash map bucket to remove the data from.
- * \param free_key_fn The function to free the key.
- * \param free_value_fn The function to free the value.
- */
-void hash_table_bucket_remove(hash_table_bucket *bucket, generic_free free_key_fn, generic_free free_value_fn);
-
-/**
- * \fn void hash_table_bucket_destroy(hash_table_bucket *bucket, generic_free free_key_fn, generic_free free_value_fn)
- * \brief Destroys a hash map bucket.
- * \param bucket The hash map bucket to destroy.
- * \param free_key_fn The function to free the key.
- * \param free_value_fn The function to free the value.
- */
-void hash_table_bucket_destroy(hash_table_bucket *bucket, generic_free free_key_fn, generic_free free_value_fn);
-
-/**
- * \fn void hash_table_bucket_print(hash_table_bucket bucket, generic_print print_key_fn, generic_print print_value_fn)
- * \brief Prints a hash map bucket.
- * \param bucket The hash map bucket to print.
- * \param print_key_fn The function to print the key.
- * \param print_value_fn The function to print the value.
- */
-void hash_table_bucket_print(hash_table_bucket bucket, generic_print print_key_fn, generic_print print_value_fn);
+#include "base/kv_generic.h"
+#include "base/kv_linked_list.h"
 
 /**
  * \typedef hash_table
@@ -191,87 +20,83 @@ typedef struct hash_table hash_table;
 struct hash_table
 {
     long int capacity;
-    hash_table_bucket *buckets;
+    KV_linked_list *buckets;
 };
 
 /**
  * \fn hash_table hash_table_create(long int capacity)
  * \brief Creates a hash map.
- * \return The created hash map.
  * \param capacity The capacity of the hash map.
+ * \return hash_table The created hash map.
  */
 hash_table hash_table_create(long int capacity);
 
 /**
- * \fn void hash_table_destroy(hash_table *map, generic_free free_key_fn, generic_free free_value_fn)
+ * \fn void hash_table_destroy(hash_table *map, KV_free free_fn)
  * \brief Destroys a hash map.
  * \param map The hash map to destroy.
- * \param free_key_fn The function to free the key.
- * \param free_value_fn The function to free the value.
+ * \param free_fn The function to free the key and value.
  */
-void hash_table_destroy(hash_table *map, generic_free free_key_fn, generic_free free_value_fn);
+void hash_table_destroy(hash_table *map, KV_free free_fn);
 
 /**
- * \fn void hash_table_insert(hash_table *map, any key, generic_hash hash_key_fn, generic_copy copy_key_fn, any value, generic_copy copy_value_fn)
- * \brief Inserts data into a hash map.
- * \param map The hash map to insert the data into.
- * \param key The key to insert.
- * \param hash_key_fn The function to hash the key.
- * \param copy_key_fn The function to copy the key.
- * \param value The value to insert.
- * \param copy_value_fn The function to copy the value.
+ * \fn void hash_table_insert(hash_table *map, KV entry, KV_copy copy_fn, KV_hash hash_fn, KV_compare equal_fn)
+ * \brief Inserts a key-value pair into a hash map.
+ * \param map The hash map to insert into.
+ * \param entry The key-value pair to insert.
+ * \param copy_fn The function to copy the key and value.
+ * \param hash_fn The function to hash the key.
+ * \param equal_fn The function to compare the keys.
  */
-void hash_table_insert(hash_table *map, any key, generic_hash hash_key_fn, generic_copy copy_key_fn, any value, generic_copy copy_value_fn);
+void hash_table_insert(hash_table *map, KV entry, KV_copy copy_fn, KV_hash hash_fn, KV_compare equal_fn);
 
 /**
- * \fn void hash_table_remove(hash_table *map, any key, generic_hash hash_key_fn, generic_compare equal_key_fn, generic_free free_key_fn, generic_free free_value_fn)
- * \brief Removes data from a hash map.
- * \param map The hash map to remove the data from.
- * \param key The key to remove.
- * \param hash_key_fn The function to hash the key.
- * \param equal_key_fn The function to compare the key.
- * \param free_key_fn The function to free the key.
- * \param free_value_fn The function to free the value.
+ * \fn void hash_table_remove(hash_table *map, any key, KV_hash hash_fn, KV_compare equal_fn, KV_free free_fn)
+ * \brief Removes a key-value pair from a hash map.
+ * \param map The hash map to remove from.
+ * \param key The key of the key-value pair to remove.
+ * \param hash_fn The function to hash the key.
+ * \param equal_fn The function to compare the keys.
+ * \param free_fn The function to free the key and value.
  */
-void hash_table_remove(hash_table *map, any key, generic_hash hash_key_fn, generic_compare equal_key_fn, generic_free free_key_fn, generic_free free_value_fn);
+void hash_table_remove(hash_table *map, any key, KV_hash hash_fn, KV_compare equal_fn, KV_free free_fn);
 
 /**
- * \fn any hash_table_get(hash_table map, any key, generic_hash hash_key_fn, generic_compare equal_key_fn)
- * \brief Gets data from a hash map.
- * \return The data from the hash map.
- * \param map The hash map to get the data from.
- * \param key The key to get.
- * \param hash_key_fn The function to hash the key.
- * \param equal_key_fn The function to compare the key.
+ * \fn any hash_table_get(hash_table map, any key, KV_hash hash_fn, KV_compare equal_fn)
+ * \brief Gets a value from a hash map.
+ * \param map The hash map to get from.
+ * \param key The key of the key-value pair to get.
+ * \param hash_fn The function to hash the key.
+ * \param equal_fn The function to compare the keys.
+ * \return any The value of the key-value pair.
  */
-any hash_table_get(hash_table map, any key, generic_hash hash_key_fn, generic_compare equal_key_fn);
+any hash_table_get(hash_table map, any key, KV_hash hash_fn, KV_compare equal_fn);
 
 /**
- * \fn bool hash_table_has(hash_table map, any key, generic_hash hash_key_fn, generic_compare equal_key_fn)
- * \brief Checks if a hash map has data.
- * \return Whether the hash map has data.
+ * \fn bool hash_table_has(hash_table map, any key, KV_hash hash_fn, KV_compare equal_fn)
+ * \brief Checks if a hash map has a key.
  * \param map The hash map to check.
- * \param key The key to check.
- * \param hash_key_fn The function to hash the key.
- * \param equal_key_fn The function to compare the key.
+ * \param key The key to check for.
+ * \param hash_fn The function to hash the key.
+ * \param equal_fn The function to compare the keys.
+ * \return bool True if the hash map has the key, false otherwise.
  */
-bool hash_table_has(hash_table map, any key, generic_hash hash_key_fn, generic_compare equal_key_fn);
+bool hash_table_has(hash_table map, any key, KV_hash hash_fn, KV_compare equal_fn);
 
 /**
  * \fn long int hash_table_size(hash_table map)
  * \brief Gets the size of a hash map.
- * \return The size of the hash map.
- * \param map The hash map to get the size from.
+ * \param map The hash map to get the size of.
+ * \return long int The size of the hash map.
  */
 long int hash_table_size(hash_table map);
 
 /**
- * \fn void hash_table_print(hash_table map, generic_print print_key_fn, generic_print print_value_fn)
+ * \fn void hash_table_print(hash_table map, KV_print print_fn)
  * \brief Prints a hash map.
  * \param map The hash map to print.
- * \param print_key_fn The function to print the key.
- * \param print_value_fn The function to print the value.
+ * \param print_fn The function to print the key and value.
  */
-void hash_table_print(hash_table map, generic_print print_key_fn, generic_print print_value_fn);
+void hash_table_print(hash_table map, KV_print print_fn);
 
-#endif // __HASH_MAP_H__
+#endif // __HASH_TABLE_H__

--- a/include/tests/hash_table.h
+++ b/include/tests/hash_table.h
@@ -1,8 +1,6 @@
 #ifndef __TESTS_HASH_TABLE_H__
 #define __TESTS_HASH_TABLE_H__
 
-void test_hash_table_bucket(void);
-
 void test_hash_table_create(void);
 void test_hash_table_add(void);
 void test_hash_table_add_overflow(void);

--- a/src/base/hash_table.c
+++ b/src/base/hash_table.c
@@ -2,223 +2,101 @@
 #include <stdbool.h>
 #include <assert.h>
 
-#include "base/generic.h"
-#include "base/linked_list.h"
+#include "base/kv_generic.h"
+#include "base/kv_linked_list.h"
 #include "base/hash_table.h"
-
-any hash_table_entry_copy(any entry_data)
-{
-    hash_table_entry_copy_transfer *data = (hash_table_entry_copy_transfer *)entry_data;
-
-    hash_table_entry *copy = malloc(sizeof(hash_table_entry));
-
-    copy->key = data->copy_key_fn(data->entry->key);
-    copy->value = data->copy_value_fn(data->entry->value);
-
-    return copy;
-}
-
-void hash_table_entry_free(any entry_data)
-{
-    hash_table_entry_free_transfer *data = (hash_table_entry_free_transfer *)entry_data;
-
-    data->free_key_fn(data->entry->key);
-    data->free_value_fn(data->entry->value);
-    free(data->entry);
-}
-
-void hash_table_entry_print(any entry_data, generic_print print_key_fn, generic_print print_value_fn)
-{
-    hash_table_entry *data = (hash_table_entry *)entry_data;
-
-    print_key_fn(data->key);
-    printf("=>");
-    print_value_fn(data->value);
-    printf("\n");
-}
-
-hash_table_bucket hash_table_bucket_create(void)
-{
-    return linked_list_create();
-}
-
-bool hash_table_bucket_is_empty(hash_table_bucket bucket)
-{
-    return linked_list_is_empty(bucket);
-}
-
-hash_table_bucket hash_table_bucket_get_next(hash_table_bucket bucket)
-{
-    assert(!hash_table_bucket_is_empty(bucket));
-
-    return linked_list_get_next(bucket);
-}
-
-void hash_table_bucket_set_next(hash_table_bucket bucket, hash_table_bucket next)
-{
-    assert(!hash_table_bucket_is_empty(bucket));
-
-    linked_list_set_next(bucket, next);
-}
-
-hash_table_entry hash_table_bucket_get_data(hash_table_bucket bucket)
-{
-    assert(!hash_table_bucket_is_empty(bucket));
-
-    return *(hash_table_entry *)linked_list_get_data(bucket);
-}
-
-void hash_table_bucket_set_data(hash_table_bucket bucket, hash_table_entry data, generic_copy copy_key_fn, generic_copy copy_value_fn)
-{
-    assert(!hash_table_bucket_is_empty(bucket));
-
-    hash_table_entry entry = {data.key, data.value};
-    hash_table_entry_copy_transfer transfer = {
-        &entry,
-        copy_key_fn,
-        copy_value_fn};
-
-    linked_list_set_data(bucket, &transfer, hash_table_entry_copy);
-}
-
-long int hash_table_bucket_length(hash_table_bucket bucket)
-{
-    return linked_list_length(bucket);
-}
-
-void hash_table_bucket_insert(hash_table_bucket *bucket, hash_table_entry data, generic_copy copy_key_fn, generic_copy copy_value_fn)
-{
-    hash_table_entry entry = {data.key, data.value};
-    hash_table_entry_copy_transfer transfer = {
-        &entry,
-        copy_key_fn,
-        copy_value_fn};
-
-    linked_list_add(bucket, &transfer, hash_table_entry_copy);
-}
-
-void hash_table_bucket_remove(hash_table_bucket *bucket, generic_free free_key_fn, generic_free free_value_fn)
-{
-    hash_table_entry data = hash_table_bucket_get_data(*bucket);
-    hash_table_bucket next = hash_table_bucket_get_next(*bucket);
-
-    free_key_fn(data.key);
-    free_value_fn(data.value);
-    free((*bucket)->data);
-    free(*bucket);
-
-    *bucket = next;
-}
-
-void hash_table_bucket_destroy(hash_table_bucket *bucket, generic_free free_key_fn, generic_free free_value_fn)
-{
-    while (!hash_table_bucket_is_empty(*bucket))
-    {
-        hash_table_bucket_remove(bucket, free_key_fn, free_value_fn);
-    }
-
-    *bucket = hash_table_bucket_create();
-}
-
-void hash_table_bucket_print(hash_table_bucket bucket, generic_print print_key_fn, generic_print print_value_fn)
-{
-    while (!hash_table_bucket_is_empty(bucket))
-    {
-        hash_table_entry_print(linked_list_get_data(bucket), print_key_fn, print_value_fn);
-        printf(" -> ");
-        bucket = hash_table_bucket_get_next(bucket);
-    }
-}
 
 hash_table hash_table_create(long int capacity)
 {
     hash_table map;
     map.capacity = capacity;
-    map.buckets = malloc(sizeof(hash_table_bucket) * capacity);
+    map.buckets = malloc(sizeof(KV_linked_list) * capacity);
 
     for (long int i = 0; i < capacity; i++)
     {
-        map.buckets[i] = hash_table_bucket_create();
+        map.buckets[i] = KV_linked_list_create();
     }
 
     return map;
 }
 
-void hash_table_destroy(hash_table *map, generic_free free_key_fn, generic_free free_value_fn)
+void hash_table_destroy(hash_table *map, KV_free free_fn)
 {
     for (long int i = 0; i < map->capacity; i++)
     {
-        hash_table_bucket_destroy(&map->buckets[i], free_key_fn, free_value_fn);
+        KV_linked_list_destroy(&map->buckets[i], free_fn);
     }
 
     free(map->buckets);
     map->capacity = 0;
 }
 
-void hash_table_insert(hash_table *map, any key, generic_hash hash_key_fn, generic_copy copy_key_fn, any value, generic_copy copy_value_fn)
+void hash_table_insert(hash_table *map, KV entry, KV_copy copy_fn, KV_hash hash_fn, KV_compare equal_fn)
 {
-    long int index = hash_key_fn(key) % map->capacity;
-
-    hash_table_entry entry = {key, value};
-    hash_table_bucket_insert(&map->buckets[index], entry, copy_key_fn, copy_value_fn);
+    long int index = hash_fn(entry) % map->capacity;
+    KV_linked_list_add(&map->buckets[index], entry, copy_fn);
 }
 
-void hash_table_remove(hash_table *map, any key, generic_hash hash_key_fn, generic_compare equal_key_fn, generic_free free_key_fn, generic_free free_value_fn)
+void hash_table_remove(hash_table *map, any key, KV_hash hash_fn, KV_compare equal_fn, KV_free free_fn)
 {
-    long int index = hash_key_fn(key) % map->capacity;
+    KV data = (KV){key, NULL};
+    long int index = hash_fn(data) % map->capacity;
 
-    hash_table_bucket bucket = map->buckets[index];
+    KV_linked_list bucket = map->buckets[index];
 
-    while (!hash_table_bucket_is_empty(bucket))
+    while (!KV_linked_list_is_empty(bucket))
     {
-        hash_table_entry entry = hash_table_bucket_get_data(bucket);
+        KV entry = KV_linked_list_get_data(bucket);
 
-        if (equal_key_fn(entry.key, key))
+        if (equal_fn(entry, data))
         {
-            hash_table_bucket_remove(&bucket, free_key_fn, free_value_fn);
+            KV_linked_list_remove(&bucket, free_fn);
             map->buckets[index] = bucket;
             return;
         }
     }
 }
 
-any hash_table_get(hash_table map, any key, generic_hash hash_key_fn, generic_compare equal_key_fn)
+any hash_table_get(hash_table map, any key, KV_hash hash_fn, KV_compare equal_fn)
 {
-    long int index = hash_key_fn(key) % map.capacity;
+    KV data = {key, NULL};
+    long int index = hash_fn(data) % map.capacity;
 
-    hash_table_bucket bucket = map.buckets[index];
+    KV_linked_list bucket = map.buckets[index];
 
-    while (!hash_table_bucket_is_empty(bucket))
+    while (!KV_linked_list_is_empty(bucket))
     {
-        hash_table_entry entry = hash_table_bucket_get_data(bucket);
+        KV entry = KV_linked_list_get_data(bucket);
 
-        if (equal_key_fn(entry.key, key))
+        if (equal_fn(entry, data))
         {
             return entry.value;
         }
 
-        bucket = hash_table_bucket_get_next(bucket);
+        bucket = KV_linked_list_get_next(bucket);
     }
 
+    assert(false);
     return NULL;
 }
 
-bool hash_table_has(hash_table map, any key, generic_hash hash_key_fn, generic_compare equal_key_fn)
+bool hash_table_has(hash_table map, any key, KV_hash hash_fn, KV_compare equal_fn)
 {
-    long int index = hash_key_fn(key) % map.capacity;
+    KV data = {key, NULL};
+    long int index = hash_fn(data) % map.capacity;
 
-    hash_table_bucket bucket = map.buckets[index];
+    KV_linked_list bucket = map.buckets[index];
 
-    while (!hash_table_bucket_is_empty(bucket))
+    while (!KV_linked_list_is_empty(bucket))
     {
-        hash_table_entry entry = hash_table_bucket_get_data(bucket);
+        KV entry = KV_linked_list_get_data(bucket);
 
-        if (equal_key_fn(entry.key, key))
+        if (equal_fn(entry, data))
         {
             return true;
         }
 
-        bucket = hash_table_bucket_get_next(bucket);
+        bucket = KV_linked_list_get_next(bucket);
     }
 
     return false;
@@ -230,18 +108,18 @@ long int hash_table_size(hash_table map)
 
     for (long int i = 0; i < map.capacity; i++)
     {
-        size += hash_table_bucket_length(map.buckets[i]);
+        size += KV_linked_list_length(map.buckets[i]);
     }
 
     return size;
 }
 
-void hash_table_print(hash_table map, generic_print print_key_fn, generic_print print_value_fn)
+void hash_table_print(hash_table map, KV_print print_fn)
 {
     for (long int i = 0; i < map.capacity; i++)
     {
         printf("%ld: ", i);
-        hash_table_bucket_print(map.buckets[i], print_key_fn, print_value_fn);
+        KV_linked_list_print(map.buckets[i], print_fn);
         printf("\n");
     }
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -201,11 +201,11 @@ int main(void)
     }
 
     if (
-        NULL == CU_add_test(pSuite, "hash_table_bucket()", test_hash_table_bucket) ||
         NULL == CU_add_test(pSuite, "hash_table_create()", test_hash_table_create) ||
         NULL == CU_add_test(pSuite, "hash_table_add()", test_hash_table_add) ||
         NULL == CU_add_test(pSuite, "hash_table_add_overflow()", test_hash_table_add_overflow) ||
         NULL == CU_add_test(pSuite, "hash_table_remove()", test_hash_table_remove) ||
+        NULL == CU_add_test(pSuite, "hash_table_find()", test_hash_table_find) ||
         NULL == CU_add_test(pSuite, "hash_table_destroy()", test_hash_table_destroy))
     {
         CU_cleanup_registry();


### PR DESCRIPTION
KV linked list is the appropriate dynamic data type. This PR uses it instead of the basic linked list using workarounds.